### PR TITLE
Allow to customise the footer text

### DIFF
--- a/inst/pkgdown/templates/footer.html
+++ b/inst/pkgdown/templates/footer.html
@@ -1,12 +1,12 @@
 <div class="copyright">
   <p>
-    {{{yaml.footer}}}{{^yaml.footer}}Developed by {{#package}}{{{authors}}}{{/package}}.{{/yaml.footer}}
-    </p>
+    Developed by {{#package}}{{{authors}}}{{/package}}.
+    {{#yaml.footer}}<br>{{{yaml.footer}}}{{/yaml.footer}}
+  </p>
 </div>
 
 <div class="pkgdown">
   <p>
-    {{#yaml.footer}}Developed by {{#package}}{{{authors}}}{{/package}}.{{/yaml.footer}}
-    Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> {{#pkgdown}}{{version}}{{/pkgdown}} and <a href="https://preferably.amirmasoudabdol.name/?source=footer">preferably</a>.
+    Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> and <a href="https://preferably.amirmasoudabdol.name/?source=footer">preferably</a>.
   </p>
 </div>

--- a/inst/pkgdown/templates/footer.html
+++ b/inst/pkgdown/templates/footer.html
@@ -1,7 +1,12 @@
 <div class="copyright">
-  <p>{{#package}}Developed by {{{authors}}}.{{/package}}</p>
+  <p>
+    {{{yaml.footer}}}{{^yaml.footer}}Developed by {{#package}}{{{authors}}}{{/package}}.{{/yaml.footer}}
+    </p>
 </div>
 
 <div class="pkgdown">
-  <p>Made with <a href="https://pkgdown.r-lib.org/">pkgdown</a> {{#pkgdown}}{{version}}{{/pkgdown}}, using <a href="https://preferably.amirmasoudabdol.name/?source=footer">preferably</a> template.</p>
+  <p>
+    {{#yaml.footer}}Developed by {{#package}}{{{authors}}}{{/package}}.{{/yaml.footer}}
+    Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> {{#pkgdown}}{{version}}{{/pkgdown}} and <a href="https://preferably.amirmasoudabdol.name/?source=footer">preferably</a>.
+  </p>
 </div>


### PR DESCRIPTION
By adding a parameter in `_pkgdown.yml` we can customize the footer text: 

``` yaml
template:
  package: preferably
  params:
    footer: This package is a part of our <a href="">awesome project</a>.
```

If the `footer` parameter is set, the text is displayed on the left and the authors list is moved to the right (with the mention of pkgdown and preferably). If not, the footer is displayed as usual.