### PR TITLE
Move theme specific features to relevant file

### DIFF
--- a/inst/pkgdown/BS3/assets/code-color-scheme-dark.css
+++ b/inst/pkgdown/BS3/assets/code-color-scheme-dark.css
@@ -46,3 +46,7 @@ a.sourceLine:hover {
 .message { color: black;   font-weight: bolder;}
 .error   { color: orange;  font-weight: bolder;}
 .warning { color: #6A0366; font-weight: bolder;}
+
+aside {
+  background: #222;
+}

--- a/inst/pkgdown/BS5/assets/code-color-scheme-light.css
+++ b/inst/pkgdown/BS5/assets/code-color-scheme-light.css
@@ -46,3 +46,7 @@ pre code span.va      {color: #3032da;} /* values */
 pre code span.message { color: black;   font-weight: bolder;}
 pre code span.error   { color: orange;  font-weight: bolder;}
 pre code span.warning { color: #6A0366; font-weight: bolder;}
+
+aside {
+  background: #fff;
+}

--- a/inst/pkgdown/BS5/assets/preferably.css
+++ b/inst/pkgdown/BS5/assets/preferably.css
@@ -22,22 +22,6 @@ pre, code, pre.usage, code.sourceCode.r, .sourceCode, .examples, .downlit, .sour
     margin-top: -8px;
 }
 
-@media (prefers-color-scheme: light) {
-
-    aside {
-        background: #ffffff;
-    }
-
-}
-
-@media (prefers-color-scheme: dark) {
-
-    aside {
-        background: #222222;
-    }
-
-}
-
 h1 {
     margin-top: 3rem !important;
 }


### PR DESCRIPTION
Fix https://github.com/epiforecasts/epinowcast/issues/159.

There are probably other ways to fix this but I think it makes sense to put all the dark-/light-specific settings in a single file instead of having some in the `code-color-schema-....csv` file and some in `preferably.css`

Tested in https://github.com/Bisaloo/test_preferably.