### PR TITLE
Remove search form from navbar.html

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ URL: https://preferably.amirmasoudabdol.name
 BugReports: https://github.com/amirmasoudabdol/preferably/issues
 Depends:
     R (>= 3.1.0),
-    pkgdown,
+    pkgdown (>= 2.1.0),
     knitr
 VignetteBuilder: 
     knitr

--- a/inst/pkgdown/BS5/templates/navbar.html
+++ b/inst/pkgdown/BS5/templates/navbar.html
@@ -18,10 +18,6 @@
       </ul>
       {{/left}}
 
-      <form class="form-inline my-2 my-lg-0" role="search">
-        <input type="search" class="form-control me-sm-2" aria-label="{{#translate}}{{toggle_nav}}{{/translate}}" name="search-input" data-search-index="{{#site}}{{root}}{{/site}}search.json" id="search-input" placeholder="{{#translate}}{{search_for}}{{/translate}}" autocomplete="off">
-      </form>
-
       {{#right}}
       <ul class="navbar-nav">
       {{{.}}}


### PR DESCRIPTION
Since pkgdown now adds as part of the standard navbar metadata.